### PR TITLE
Support DNS even if use_ip is set.

### DIFF
--- a/lib/rubix/log.rb
+++ b/lib/rubix/log.rb
@@ -30,7 +30,7 @@ module Rubix
   #
   # Will attempt to read from
   #
-  # - <tt>Settings[:log_level]</tt> if <tt>Settings</tt> is defined (see Configliere[http://github.com/infochimps/configliere])
+  # - <tt>Settings[:log_level]</tt> if <tt>Settings</tt> is defined (see Configliere[https://github.com/infochimps-labs/configliere])
   # - the <tt>RUBIX_LOG_LEVEL</tt> environment variable if defined
   #
   # The default is 'info'.
@@ -57,7 +57,7 @@ module Rubix
   #
   # Will attempt to read from
   #
-  # - <tt>Settings[:log]</tt> if <tt>Settings</tt> is defined (see Configliere[http://github.com/infochimps/configliere])
+  # - <tt>Settings[:log]</tt> if <tt>Settings</tt> is defined (see Configliere[https://github.com/infochimps-labs/configliere])
   # - the <tt>RUBIX_LOG_PATH</tt> environment variable if defined
   #
   # Defaults to writing <tt>stdout</tt>.

--- a/lib/rubix/models/host.rb
+++ b/lib/rubix/models/host.rb
@@ -103,6 +103,8 @@ module Rubix
     def validate
       raise ValidationError.new("A host must have at least one host group.") if host_group_ids.nil? || host_group_ids.empty?
       raise ValidationError.new("A host must have a valid ip address if use_ip is set.") if use_ip && ip == self.class::BLANK_IP
+      raise ValidationError.new("A host must have an ip address if use_ip is set.") if use_ip && (ip.nil? || ip.empty?)
+      raise ValidationError.new("A host must have a dns name if use_ip is false.") if !use_ip && dns.nil?
       raise ValidationError.new("A host must have a ipmi_privilege defined as one of: " + self.class::IPMI_PRIVILEGE_CODES.keys.to_s) if use_ipmi && self.class::IPMI_PRIVILEGE_CODES[ipmi_privilege].nil?
       raise ValidationError.new("A host must have a ipmi_authtype defined as one of: " + self.class::IPMI_AUTH_CODES.keys.to_s) if use_ipmi && self.class::IPMI_AUTH_CODES[ipmi_authtype].nil?
       true
@@ -121,20 +123,17 @@ module Rubix
       }.tap do |hp|
         hp[:profile] = profile if profile
         hp[:profile].delete("hostid") if hp[:profile] && hp[:profile]["hostid"]
-        
         hp[:status]  = (monitored ? 0 : 1) unless monitored.nil?
         
         # Check to see if use_ip is set, otherwise we will use dns
         hp[:useip]          = (use_ip == true ? 1 : 0)
         
-        # if we have an IP then use it, otherwise use 0.0.0.0
+        # if we have an IP then use it, otherwise use 0.0.0.0, same goes for the port
         hp[:ip]             = ip   || self.class::BLANK_IP
-        
-        # enter a dns record if we provide it no matter what
-        hp[:dns]            = dns           if dns
-        
-        # honor the provided port, otherwise use the default
         hp[:port]           = port || self.class::DEFAULT_PORT
+        
+        # Always allow for a DNS record to exist even if we dont use it to monitor.
+        hp[:dns]            = dns           if dns
         
         hp[:useipmi]        = (use_ipmi == true ? 1 : 0)
         hp[:ipmi_port]      = ipmi_port     if ipmi_port


### PR DESCRIPTION
IP and DNS should be filled even if use_ip is set. I also added more validations to save a user from entering a less than intelligent host definition around IPs and DNS.
